### PR TITLE
Refactor the storage consumer contracts

### DIFF
--- a/contracts/StorageConsumer/StorageConsumer.sol
+++ b/contracts/StorageConsumer/StorageConsumer.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.4.18;
 
 import "../Storage/BaseStorage.sol";
-import "./StorageConsumerState.sol";
+import "./StorageStateful.sol";
 
-contract StorageConsumer is StorageConsumerState {
-  function StorageConsumer(BaseStorage store) public {
-    _storage.store = store;
+contract StorageConsumer is StorageStateful {
+  function StorageConsumer(BaseStorage storage_) public {
+    _storage = storage_;
   }
 }

--- a/contracts/StorageConsumer/StorageConsumerLib.sol
+++ b/contracts/StorageConsumer/StorageConsumerLib.sol
@@ -1,9 +1,0 @@
-pragma solidity ^0.4.18;
-
-import "../Storage/BaseStorage.sol";
-
-library StorageConsumerLib {
-  struct Storage {
-    BaseStorage store;
-  }
-}

--- a/contracts/StorageConsumer/StorageConsumerState.sol
+++ b/contracts/StorageConsumer/StorageConsumerState.sol
@@ -1,7 +1,0 @@
-pragma solidity ^0.4.18;
-
-import "./StorageConsumerLib.sol";
-
-contract StorageConsumerState {
-  StorageConsumerLib.Storage _storage;
-}

--- a/contracts/StorageConsumer/StorageStateful.sol
+++ b/contracts/StorageConsumer/StorageStateful.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.18;
+
+import "../Storage/BaseStorage.sol";
+
+contract StorageStateful {
+  BaseStorage _storage;
+}


### PR DESCRIPTION
they don't need to use a struct. Libraries can deal directly with BaseStorage instead of the struct.

also `StorageStateful` felt like a better name